### PR TITLE
Setup service connect and fix WAF issue for TinyMCE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changle Log
 
 ### Added
+- Added exception to WAF to allow TinyMCE content to pass through
 - Added CodeBuild, CodePipeline and ECS service for the new dmptool-narrative-generator service
 - Added Firelens and Fluentbit long configuration for all ECS tasks
 - Created stage environment (porting over initial files from dmsp_aws_prototype repo) 
 
 ### Updated
+- Updated nextJS task definition to use our Firelens image
 - 2025-09-10 -- Bumped MySQL to v8.4.6
 - Updated Fluentbit config to push everything into an `extra` field and then pull only the fields we want to be able to filter by to the top level.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changle Log
 
 ### Added
+- Added service connect configuration to all ECS services
+- Added CloudMap Namespace to support service connect
 - Added exception to WAF to allow TinyMCE content to pass through
 - Added CodeBuild, CodePipeline and ECS service for the new dmptool-narrative-generator service
 - Added Firelens and Fluentbit long configuration for all ECS tasks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Created stage environment (porting over initial files from dmsp_aws_prototype repo) 
 
 ### Updated
+- 2025-09-10 -- Bumped MySQL to v8.4.6
 
 ### Removed
 

--- a/config/dev/cloud-map.yaml
+++ b/config/dev/cloud-map.yaml
@@ -1,0 +1,6 @@
+template:
+  path: 'cloud-map.yaml'
+  type: 'file'
+
+parameters:
+  Env: !stack_attr sceptre_user_data.env

--- a/config/dev/ecs/apollo.yaml
+++ b/config/dev/ecs/apollo.yaml
@@ -10,6 +10,8 @@ parameters:
   Domain: !stack_attr sceptre_user_data.domain
   ContainerName: !stack_attr sceptre_user_data.apollo_container_name
 
+  CloudMapNamespaceARN: !stack_output dev/cloud-map.yaml::NamespaceARN
+
   DefaultAffiliationUri: !stack_output dev/ssm.yaml::DefaultAffiliationSsmParameter
   DoiBase: !stack_output dev/ssm.yaml::EzidBaseUrlSsmParameter
   DoiShoulder: !ssm /uc3/dmp/tool/dev/EzidShoulder

--- a/config/dev/ecs/narrative-generator.yaml
+++ b/config/dev/ecs/narrative-generator.yaml
@@ -11,6 +11,8 @@ parameters:
   ContainerName: !stack_attr sceptre_user_data.narrative_generator_name
   AppPort: !stack_attr sceptre_user_data.narrative_generator_port
 
+  CloudMapNamespaceARN: !stack_output dev/cloud-map.yaml::NamespaceARN
+
   EcrRepositoryUri: !stack_output dev/ecr.yaml::EcrRepositoryURI
   EcrImageTag: !stack_attr sceptre_user_data.narrative_generator_tag
 

--- a/config/dev/ecs/nextJS.yaml
+++ b/config/dev/ecs/nextJS.yaml
@@ -14,6 +14,8 @@ parameters:
   Domain: !stack_attr sceptre_user_data.domain
   ContainerName: !stack_attr sceptre_user_data.nextjs_container_name
 
+  CloudMapNamespaceARN: !stack_output dev/cloud-map.yaml::NamespaceARN
+
   AppPort: !stack_attr sceptre_user_data.nextjs_container_port
 
   EcrRepositoryUri: !stack_output dev/ecr.yaml::EcrRepositoryURI

--- a/config/dev/ecs/nextJS.yaml
+++ b/config/dev/ecs/nextJS.yaml
@@ -32,6 +32,12 @@ parameters:
   OpenSearchCollection: !stack_attr sceptre_user_data.opensearch_log_collection
   OpenSearchCollectionArn: !stack_attr sceptre_user_data.opensearch_log_collection_arn
 
+  ApolloServerPort: !stack_attr sceptre_user_data.apollo_container_port
+  NarrativeGeneratorPort: !stack_attr sceptre_user_data.narrative_generator_port
+
+  AwsFirelensRepositoryUri: !stack_output dev/ecr.yaml::AwsFirelensRepositoryURI
+  AwsFirelensImageTag: "latest"
+
   EcsDesiredServiceCount: '2'
 
   CpuSize: '2048'

--- a/config/dev/rds.yaml
+++ b/config/dev/rds.yaml
@@ -22,7 +22,7 @@ parameters:
   # Valid options are based on the DB engine.
   # Use this to see what versions are availanle: `aws rds describe-db-engine-versions --default-only --engine mysql`
   DbEngine: 'mysql'
-  DbEngineVersion: '8.4.4'
+  DbEngineVersion: '8.4.6'
   LicenseModel: 'general-public-license'
 
   DbBackupRetentionDays: '35'

--- a/config/stg/rds.yaml
+++ b/config/stg/rds.yaml
@@ -22,7 +22,7 @@ parameters:
   # Valid options are based on the DB engine.
   # Use this to see what versions are availanle: `aws rds describe-db-engine-versions --default-only --engine mysql`
   DbEngine: 'mysql'
-  DbEngineVersion: '8.4.4'
+  DbEngineVersion: '8.4.6'
   LicenseModel: 'general-public-license'
 
   DbBackupRetentionDays: '35'

--- a/templates/alb.yaml
+++ b/templates/alb.yaml
@@ -131,6 +131,9 @@ Resources:
       HealthCheckTimeoutSeconds: 60
       UnhealthyThresholdCount: 2
       Matcher:
+        # TODO: For some reason the Healthcheck is returning a 301 instead of 200
+        #       so expanding this to allow for that. When you hit the path from a
+        #       browser or curl though it returns a 200
         HttpCode: '200-399'
       VpcId: !Ref VpcId
       Port: !Ref NextJsPort

--- a/templates/alb.yaml
+++ b/templates/alb.yaml
@@ -131,9 +131,6 @@ Resources:
       HealthCheckTimeoutSeconds: 60
       UnhealthyThresholdCount: 2
       Matcher:
-        # TODO: For some reason the Healthcheck is returning a 301 instead of 200
-        #       so expanding this to allow for that. When you hit the path from a
-        #       browser or curl though it returns a 200
         HttpCode: '200-399'
       VpcId: !Ref VpcId
       Port: !Ref NextJsPort

--- a/templates/cloud-map.yaml
+++ b/templates/cloud-map.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: 'CloudMap service connect'
+
+Parameters:
+  Env:
+    Type: 'String'
+    Default: 'dev'
+
+Resources:
+  # AWS CloudMap resources to support service connect (allowing ECS containers to find
+  # other services by name)
+  #   See: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/AWS_ServiceDiscovery.html
+  Namespace:
+    Type: 'AWS::ServiceDiscovery::HttpNamespace'
+    Properties:
+      Description: !Sub "CloudMap namespace for DMP Tool ${Env} ECS services"
+      Name: !Sub "dmptool-${Env}"
+
+Outputs:
+  NamespaceId:
+    Value: !Ref Namespace
+
+  NamespaceARN:
+    Value: !GetAtt Namespace.Arn

--- a/templates/ecs/apollo.yaml
+++ b/templates/ecs/apollo.yaml
@@ -316,11 +316,11 @@ Resources:
           StartTimeout: !Ref StartTimeout
           StopTimeout: !Ref StopTimeout
           HealthCheck:
-            Command: [ "CMD-SHELL", "curl -f http://localhost:4000/up || exit 1" ]
+            Command: [ "CMD-SHELL", "wget --spider -q http://localhost:4000/up || exit 1" ]
             Interval: 30
             Retries: 3
             Timeout: 5
-            StartPeriod: 10
+            StartPeriod: 30
           LogConfiguration:
             LogDriver: 'awsfirelens'
             Options:
@@ -477,6 +477,11 @@ Resources:
               Value: !Ref DoNotReplyEmail
             - Name: 'HELPDESK_EMAIL_ADDRESS'
               Value: !Ref HelpdeskEmail
+
+            # Firelens sidecar won't redeploy unless this defintion changes
+            # Change this value to force a redeploy of the firelens sidecar
+            - Name: 'DUMMY_TO_TRIGGER_REDEPLOY_OF_SIDECARS'
+              Value: 'v1'
 
         # The AWS Firelens sidecar container to send application logs to opensearch
         - Name: !Sub "${ContainerName}Firelens${Env}"

--- a/templates/ecs/apollo.yaml
+++ b/templates/ecs/apollo.yaml
@@ -315,12 +315,12 @@ Resources:
           Name: !Ref ContainerName
           StartTimeout: !Ref StartTimeout
           StopTimeout: !Ref StopTimeout
-          # TODO: Figure out what container health check should be run (e.g. memory usage)
-          # HealthCheck:
-          #   Command:  ["CMD-SHELL", "echo hello"]
-          #   Interval: 5
-          #   Retries: 2
-          #   Timeout: 3
+          HealthCheck:
+            Command: [ "CMD-SHELL", "curl -f http://localhost:4000/up || exit 1" ]
+            Interval: 30
+            Retries: 3
+            Timeout: 5
+            StartPeriod: 10
           LogConfiguration:
             LogDriver: 'awsfirelens'
             Options:
@@ -494,6 +494,12 @@ Resources:
               max-buffer-size: '25m'
               awslogs-region: !Sub '${AWS::Region}'
               awslogs-stream-prefix: 'firelens'
+          HealthCheck:
+            Command: [ "CMD-SHELL", "pidof fluent-bit >/dev/null || exit 1" ]
+            Interval: 30
+            Retries: 3
+            Timeout: 5
+            StartPeriod: 10
           FirelensConfiguration:
             Type: 'fluentbit'
             Options:

--- a/templates/ecs/apollo.yaml
+++ b/templates/ecs/apollo.yaml
@@ -37,6 +37,9 @@ Parameters:
   ContainerName:
     Type: 'String'
 
+  CloudMapNamespaceARN:
+    Type: 'String'
+
   DefaultAffiliationUri:
     Type: 'String'
 
@@ -340,6 +343,7 @@ Resources:
               Protocol: 'tcp'
             # ALB port (The port we are listening on)
             - ContainerPort: !Ref AppPort
+              Name: !Sub "apollo_${AppPort}"
               Protocol: 'tcp'
             # RDS port (The MySQL DB port)
             - ContainerPort: !Ref DbPort
@@ -539,6 +543,15 @@ Resources:
       PropagateTags: 'TASK_DEFINITION'
       SchedulingStrategy: 'REPLICA'
       TaskDefinition: !Ref EcsTaskDefinition
+      ServiceConnectConfiguration:
+        Enabled: true
+        Namespace: !Ref CloudMapNamespaceARN
+        Services:
+          - DiscoveryName: 'apollo'
+            PortName: !Sub "apollo_${AppPort}"
+            ClientAliases:
+              - DnsName: 'apollo'
+                Port: !Ref AppPort
 
 Outputs:
   EcsTaskRoleArn:

--- a/templates/ecs/narrative-generator.yaml
+++ b/templates/ecs/narrative-generator.yaml
@@ -229,8 +229,10 @@ Resources:
             Interval: 30
             Retries: 3
             Timeout: 5
-            StartPeriod: 10
+            StartPeriod: 30
 
+          # NOTE: Leave this here for reference in case we want to disable Firelens and
+          #       start logging to CloudWatch again.
           # LogConfiguration:
           #   LogDriver: 'awslogs'
           #   Options:
@@ -320,6 +322,11 @@ Resources:
 
             - Name: 'MYSQL_QUEUE_LIMIT'
               Value: !Ref RdsQueueLimit
+
+            # Firelens sidecar won't redeploy unless this defintion changes
+            # Change this value to force a redeploy of the firelens sidecar
+            - Name: 'DUMMY_TO_TRIGGER_REDEPLOY_OF_SIDECARS'
+              Value: 'v1'
 
         # The AWS Firelens sidecar container to send application logs to opensearch
         - Name: !Sub "${ContainerName}Firelens${Env}"

--- a/templates/ecs/narrative-generator.yaml
+++ b/templates/ecs/narrative-generator.yaml
@@ -37,6 +37,9 @@ Parameters:
   ContainerName:
     Type: 'String'
 
+  CloudMapNamespaceARN:
+    Type: 'String'
+
   AppPort:
     Type: 'Number'
 
@@ -256,6 +259,7 @@ Resources:
             # ALB port (The port we are listening on)
             - ContainerPort: !Ref AppPort
               Protocol: 'tcp'
+              Name: !Sub "narrative_${AppPort}"
           Environment:
             - Name: 'AWS_REGION'
               Value: !Ref AWS::Region
@@ -382,6 +386,15 @@ Resources:
       PropagateTags: 'TASK_DEFINITION'
       SchedulingStrategy: 'REPLICA'
       TaskDefinition: !Ref EcsTaskDefinition
+      ServiceConnectConfiguration:
+        Enabled: true
+        Namespace: !Ref CloudMapNamespaceARN
+        Services:
+          - DiscoveryName: 'narrative'
+            PortName: !Sub "narrative_${AppPort}"
+            ClientAliases:
+              - DnsName: 'narrative'
+                Port: !Ref AppPort
 
 Outputs:
   EcsTaskRoleArn:

--- a/templates/ecs/narrative-generator.yaml
+++ b/templates/ecs/narrative-generator.yaml
@@ -224,12 +224,12 @@ Resources:
           Name: !Ref ContainerName
           StartTimeout: !Ref StartTimeout
           StopTimeout: !Ref StopTimeout
-          # TODO: Figure out what container health check should be run (e.g. memory usage)
-          # HealthCheck:
-          #   Command:  ["CMD-SHELL", "echo hello"]
-          #   Interval: 5
-          #   Retries: 2
-          #   Timeout: 3
+          HealthCheck:
+            Command:  ["CMD-SHELL", "curl -f http://localhost:4030/narrative-health || exit 1"]
+            Interval: 30
+            Retries: 3
+            Timeout: 5
+            StartPeriod: 10
 
           # LogConfiguration:
           #   LogDriver: 'awslogs'
@@ -328,6 +328,12 @@ Resources:
           MemoryReservation: 51
           Essential: true
           User: 0
+          HealthCheck:
+            Command: [ "CMD-SHELL", "pidof fluent-bit >/dev/null || exit 1" ]
+            Interval: 30
+            Retries: 3
+            Timeout: 5
+            StartPeriod: 10
           LogConfiguration:
             LogDriver: 'awslogs'
             Options:

--- a/templates/ecs/nextJS.yaml
+++ b/templates/ecs/nextJS.yaml
@@ -24,6 +24,21 @@ Parameters:
   OpenSearchCollectionArn:
     Type: 'String'
 
+  ApolloServerPort:
+    Type: 'Number'
+    Default: 4000
+
+  NarrativeGeneratorPort:
+    Type: 'Number'
+    Default: 4030
+
+  AwsFirelensRepositoryUri:
+    Type: 'String'
+
+  AwsFirelensImageTag:
+    Type: 'String'
+    Default: 'latest'
+
   Env:
     Type: 'String'
     Default: 'dev'
@@ -186,12 +201,12 @@ Resources:
           Name: !Ref ContainerName
           StartTimeout: !Ref StartTimeout
           StopTimeout: !Ref StopTimeout
-          HealthCheck:
-            Command:  ["CMD-SHELL", "curl -f http://localhost:3000/healthcheck || exit 1"]
-            Interval: 30
-            Retries: 3
-            Timeout: 5
-            StartPeriod: 10
+          # HealthCheck:
+          #   Command:  ["CMD-SHELL", "curl -f http://127.0.0.1:3000/en-US/login || exit 1"]
+          #   Interval: 30
+          #   Retries: 3
+          #   Timeout: 5
+          #   StartPeriod: 60
           LogConfiguration:
             LogDriver: 'awsfirelens'
             Options:
@@ -209,13 +224,18 @@ Resources:
               tls: 'On'
               retry_limit: 2
           PortMappings:
-            # ALB port (The port we are listening on)
-            - ContainerPort: !Ref AppPort
+            - ContainerPort: !Ref AppPort # ALB port (The port we are listening on)
               Protocol: 'tcp'
               Name: !Sub "nextjs_${AppPort}"
             - ContainerPort: 443
               Protocol: 'tcp'
               Name: "nextjs_443"
+            - ContainerPort: '3030' # Service connect port
+              Protocol: 'tcp'
+              Name: 'nextjs_3030'
+            - ContainerPort: 9229 # Debugging port
+              Protocol: 'tcp'
+              Name: 'nextjs_9229'
           Environment:
             # The application as it should appear in emails and other messaging
             - Name: 'APP_NAME'
@@ -241,8 +261,14 @@ Resources:
             - Name: 'NEXT_PUBLIC_GRAPHQL_SERVER_ENDPOINT'
               Value: !Sub "${Domain}/graphql"
 
+            - Name: "NEXT_PUBLIC_NARRATIVE_ENDPOINT"
+              Value: !Sub "http://narrative:${NarrativeGeneratorPort}"
+
             - Name: 'SERVER_ENDPOINT'
-              Value: !Sub "http://apollo:4000"
+              Value: !Sub "http://apollo:${ApolloServerPort}"
+
+            - Name: "SERVER_LOG_LEVEL"
+              Value: !Ref LogLevel
 
             # CDN endpoint
             - Name: "CDN_ENDPOINT"
@@ -254,7 +280,7 @@ Resources:
 
         # The AWS Firelens sidecar container to send application logs to opensearch
         - Name: !Sub "${ContainerName}Firelens${Env}"
-          Image: "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
+          Image: !Sub "${AwsFirelensRepositoryUri}:${AwsFirelensImageTag}"
           Cpu: 0
           MemoryReservation: 51
           Essential: true
@@ -325,10 +351,10 @@ Resources:
         Namespace: !Ref CloudMapNamespaceARN
         Services:
           - DiscoveryName: 'nextjs'
-            PortName: !Sub "nextjs_${AppPort}"
+            PortName: 'nextjs_3030'
             ClientAliases:
               - DnsName: 'nextjs'
-                Port: 443
+                Port: !Ref AppPort
 
 Outputs:
   EcsServiceArn:

--- a/templates/ecs/nextJS.yaml
+++ b/templates/ecs/nextJS.yaml
@@ -37,6 +37,9 @@ Parameters:
   ContainerName:
     Type: 'String'
 
+  CloudMapNamespaceARN:
+    Type: 'String'
+
   AppPort:
     Type: 'Number'
 
@@ -209,6 +212,7 @@ Resources:
             # ALB port (The port we are listening on)
             - ContainerPort: !Ref AppPort
               Protocol: 'tcp'
+              Name: !Sub "nextjs_${AppPort}"
           Environment:
             # The application as it should appear in emails and other messaging
             - Name: 'APP_NAME'
@@ -235,7 +239,7 @@ Resources:
               Value: !Sub "${Domain}/graphql"
 
             - Name: 'SERVER_ENDPOINT'
-              Value: !Sub "https://${Domain}"
+              Value: !Sub "http://apollo:4000"
 
             # CDN endpoint
             - Name: "CDN_ENDPOINT"
@@ -307,6 +311,15 @@ Resources:
       PropagateTags: 'TASK_DEFINITION'
       SchedulingStrategy: 'REPLICA'
       TaskDefinition: !Ref EcsTaskDefinition
+      ServiceConnectConfiguration:
+        Enabled: true
+        Namespace: !Ref CloudMapNamespaceARN
+        Services:
+          - DiscoveryName: 'nextjs'
+            PortName: !Sub "nextjs_${AppPort}"
+            ClientAliases:
+              - DnsName: 'nextjs'
+                Port: !Ref AppPort
 
 Outputs:
   EcsServiceArn:

--- a/templates/ecs/nextJS.yaml
+++ b/templates/ecs/nextJS.yaml
@@ -186,12 +186,12 @@ Resources:
           Name: !Ref ContainerName
           StartTimeout: !Ref StartTimeout
           StopTimeout: !Ref StopTimeout
-          # TODO: Figure out what container health check should be run (e.g. memory usage)
-          # HealthCheck:
-          #   Command:  ["CMD-SHELL", "echo hello"]
-          #   Interval: 5
-          #   Retries: 2
-          #   Timeout: 3
+          HealthCheck:
+            Command:  ["CMD-SHELL", "curl -f http://localhost:3000/healthcheck || exit 1"]
+            Interval: 30
+            Retries: 3
+            Timeout: 5
+            StartPeriod: 10
           LogConfiguration:
             LogDriver: 'awsfirelens'
             Options:
@@ -213,6 +213,9 @@ Resources:
             - ContainerPort: !Ref AppPort
               Protocol: 'tcp'
               Name: !Sub "nextjs_${AppPort}"
+            - ContainerPort: 443
+              Protocol: 'tcp'
+              Name: "nextjs_443"
           Environment:
             # The application as it should appear in emails and other messaging
             - Name: 'APP_NAME'
@@ -265,6 +268,12 @@ Resources:
               max-buffer-size: '25m'
               awslogs-region: !Sub '${AWS::Region}'
               awslogs-stream-prefix: 'firelens'
+          HealthCheck:
+            Command: [ "CMD-SHELL", "pidof fluent-bit >/dev/null || exit 1" ]
+            Interval: 30
+            Retries: 3
+            Timeout: 5
+            StartPeriod: 10
           FirelensConfiguration:
             Type: 'fluentbit'
           Environment:
@@ -319,7 +328,7 @@ Resources:
             PortName: !Sub "nextjs_${AppPort}"
             ClientAliases:
               - DnsName: 'nextjs'
-                Port: !Ref AppPort
+                Port: 443
 
 Outputs:
   EcsServiceArn:

--- a/templates/ecs/nextJS.yaml
+++ b/templates/ecs/nextJS.yaml
@@ -233,9 +233,7 @@ Resources:
             - ContainerPort: '3030' # Service connect port
               Protocol: 'tcp'
               Name: 'nextjs_3030'
-            - ContainerPort: 9229 # Debugging port
-              Protocol: 'tcp'
-              Name: 'nextjs_9229'
+
           Environment:
             # The application as it should appear in emails and other messaging
             - Name: 'APP_NAME'

--- a/templates/waf.yaml
+++ b/templates/waf.yaml
@@ -69,7 +69,8 @@ Resources:
             ManagedRuleGroupStatement:
               VendorName: 'AWS'
               Name: 'AWSManagedRulesCommonRuleSet'
-              ExcludedRules: []
+              ExcludedRules:
+               - Name: 'CrossSiteScripting_BODY'
         - Name: 'AWS-AWSManagedRulesKnownBadInputsRuleSet'
           Priority: 2
           OverrideAction:


### PR DESCRIPTION
- Update WAF rule to allow TinyMCE content through
- Added service connect configuration for the ECS services
- Added CloudMap namespace to support service connect
- Added container healthchecks
- Updated nextJS container's ENV variable so that it uses the service connect names instead of domain names
- Bump MySQL version to v8.4.6